### PR TITLE
Give each command its own TUF_ROOT

### DIFF
--- a/pkg/action/event.go
+++ b/pkg/action/event.go
@@ -108,6 +108,15 @@ func (event LuetEvent) Run() map[string]string {
 			args = fmt.Sprintf("echo -n '%s' | cosign %s --fulcio-url=%s sign -key %s %s", pass, cosignDebug, fulcioUrl, keyLocation, data.ImageName)
 		}
 
+		tmpDir, err := os.MkdirTemp("", "cosign-tuf-*")
+		defer os.RemoveAll(tmpDir)
+		if err != nil {
+			return helpers.WrapErrorMap(err)
+		}
+
+		// Give each cosign its own tuf dir so it doesnt collide with others accessing the same files at the same time
+		_ = os.Setenv("TUF_ROOT", tmpDir)
+
 		out, err := exec.Command("bash", "-c", args).CombinedOutput()
 
 		if err != nil {
@@ -164,6 +173,15 @@ func (event LuetEvent) Run() map[string]string {
 		} else {
 			args = fmt.Sprintf("cosign %s verify -key %s %s", cosignDebug, keyLocation, data.Image)
 		}
+
+		tmpDir, err := os.MkdirTemp("", "cosign-tuf-*")
+		defer os.RemoveAll(tmpDir)
+		if err != nil {
+			return helpers.WrapErrorMap(err)
+		}
+
+		// Give each cosign its own tuf dir so it doesnt collide with others accessing the same files at the same time
+		_ = os.Setenv("TUF_ROOT", tmpDir)
 
 		out, err := exec.Command("bash", "-c", args).CombinedOutput()
 		if err != nil {


### PR DESCRIPTION
Looks like from 1.4.x the TUF_ROOT is initialized and read from,
blocking access to the tuf database.

This resutls in errors if we are running luet with concurrency as
several files try to access the same dir adn they get blocked files.

Give each run of cosign its own temporal TUF_ROOT so there is no issues
accessing those files

Signed-off-by: Itxaka <igarcia@suse.com>